### PR TITLE
Tooltip 개선 및 시즌3 점수계산 로직 추가

### DIFF
--- a/components/TierCard.tsx
+++ b/components/TierCard.tsx
@@ -77,8 +77,8 @@ const TierCard = (stats: TierCardProps) => {
             <li>승률: {winPercent(totalGames, totalWins)}%</li>
             {seasonId > 19 ? (
               <>
-                <li>TOP2: {top2 * 100}%</li>
-                <li>TOP3: {top3 * 100}%</li>
+                <li>TOP2: {(top2 * 100).toFixed(0)}%</li>
+                <li>TOP3: {(top3 * 100).toFixed(0)}%</li>
               </>
             ) : (
               <></>

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -1,16 +1,77 @@
-import { ReactNode } from 'react'
+'use client'
+import { ReactNode, useEffect, useRef, useState } from 'react'
 
 interface TooltipProps {
   message: string | ReactNode
   children: ReactNode
 }
 export const Tooltip = ({ message, children }: TooltipProps) => {
+  const tooltipTriggerRef = useRef<HTMLDivElement>(null)
+  const tooltipRef = useRef<HTMLDivElement>(null)
+  const [isShowTooltip, setIsShowTooltip] = useState(false)
+  const [tooltipPosition, setTooltipPosition] = useState<
+    ['left' | 'right', 'top' | 'bottom']
+  >(['right', 'bottom'])
+  const [tooltipPositionStyle, setTooltipPositionStyle] = useState<any>({
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  })
+  const tooltipWidth = 200
+
+  useEffect(() => {
+    if (tooltipTriggerRef.current) {
+      const { top, left } = tooltipTriggerRef.current.getBoundingClientRect()
+
+      if (top > window.innerHeight / 2) {
+        setTooltipPosition((prev) => [prev[0], 'top'])
+        setTooltipPositionStyle({
+          bottom: tooltipTriggerRef.current?.offsetHeight!,
+        })
+      } else {
+        setTooltipPosition((prev) => [prev[0], 'bottom'])
+        setTooltipPositionStyle({
+          top: tooltipTriggerRef.current?.offsetHeight!,
+        })
+      }
+
+      if (left + tooltipWidth > window.innerWidth) {
+        setTooltipPosition((prev) => ['left', prev[1]])
+      } else {
+        setTooltipPosition((prev) => ['right', prev[1]])
+      }
+    }
+  }, [isShowTooltip])
+
+  const handleMouseEnter = () => {
+    setIsShowTooltip(true)
+  }
+  const handleMouseLeave = () => {
+    setIsShowTooltip(false)
+  }
+
+  const tooltipWidthClass = `w-[${tooltipWidth}px]`
+
   return (
-    <div className="group relative w-fit h-fit">
+    <div
+      ref={tooltipTriggerRef}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      className="group relative w-fit h-fit"
+    >
       {children}
-      <div className="absolute hidden z-50  bg-zinc-800/90 text-white m-2 p-3 w-[300px] text-sm left-0 group-hover:block group-active:block">
-        {message}
-      </div>
+      {isShowTooltip && (
+        <div
+          ref={tooltipRef}
+          className={`absolute z-50 bg-zinc-800/90 text-white m-2 p-3 text-sm box-border
+          ${tooltipWidthClass}
+        `}
+          style={tooltipPositionStyle}
+        >
+          {message}
+        </div>
+      )}
     </div>
   )
 }

--- a/tests/mmrToTier.test.ts
+++ b/tests/mmrToTier.test.ts
@@ -1,5 +1,95 @@
 import { mmrToTier } from '../util/mmrToTier'
 
+describe('mmr to tier test after 3 season', () => {
+  it('eternity mmr', () => {
+    expect(mmrToTier(7919, 1, 23)).toStrictEqual({
+      tier: 'Eternity',
+      grade: '',
+      lp: 1719,
+    })
+    expect(mmrToTier(6363, 200, 23)).toStrictEqual({
+      tier: 'Mithril',
+      grade: '',
+      lp: 163,
+    })
+  })
+  it('demigod mmr', () => {
+    expect(mmrToTier(6463, 201, 23)).toStrictEqual({
+      tier: 'Demigod',
+      grade: '',
+      lp: 263,
+    })
+    expect(mmrToTier(6198, 400, 23)).toStrictEqual({
+      tier: 'Diamond',
+      grade: 1,
+      lp: 348,
+    })
+  })
+  it('demigod mmr but low rank', () => {
+    expect(mmrToTier(6500, 701, 23)).toStrictEqual({
+      tier: 'Mithril',
+      grade: '',
+      lp: 300,
+    })
+    expect(mmrToTier(6823, 910, 23)).toStrictEqual({
+      tier: 'Mithril',
+      grade: '',
+      lp: 623,
+    })
+  })
+  it('mithril mmr', () => {
+    expect(mmrToTier(6266, 1, 23)).toStrictEqual({
+      tier: 'Mithril',
+      grade: '',
+      lp: 66,
+    })
+  })
+  it('diamond mmr', () => {
+    expect(mmrToTier(6133, 2, 23)).toStrictEqual({
+      tier: 'Diamond',
+      grade: 1,
+      lp: 283,
+    })
+  })
+  it('platinum mmr', () => {
+    expect(mmrToTier(3726, 2268, 23)).toStrictEqual({
+      tier: 'Platinum',
+      grade: 4,
+      lp: 126,
+    })
+  })
+  it('gold mmr', () => {
+    expect(mmrToTier(3237, 31967, 23)).toStrictEqual({
+      tier: 'Gold',
+      grade: 2,
+      lp: 137,
+    })
+  })
+
+  it('silver mmr test', () => {
+    expect(mmrToTier(2232, 39571, 23)).toStrictEqual({
+      tier: 'Silver',
+      grade: 2,
+      lp: 132,
+    })
+  })
+
+  it('bronze mmr test', () => {
+    expect(mmrToTier(801, 66805, 23)).toStrictEqual({
+      tier: 'Bronze',
+      grade: 4,
+      lp: 1,
+    })
+  })
+
+  it('iron mmr test', () => {
+    expect(mmrToTier(661, 66805, 23)).toStrictEqual({
+      tier: 'Iron',
+      grade: 1,
+      lp: 61,
+    })
+  })
+})
 describe('mmr to tier test after 1.0 season', () => {
   it('eternity mmr', () => {
     expect(mmrToTier(7919, 1, 19)).toStrictEqual({

--- a/util/mmrToTier.ts
+++ b/util/mmrToTier.ts
@@ -12,33 +12,89 @@ export const mmrToTier = (
 ) => {
   if (typeof seasonId === 'string') seasonId = Number(seasonId)
   let perTierLp // 1티어 단계당 필요한 lp
-  // 10 시즌(공식 1.0)부터 1티어당 250lp로 변경
-  if (seasonId >= 19) {
-    perTierLp = 250
-  } else {
-    perTierLp = 100
-  }
-  const a = Math.trunc(mmr / perTierLp)
-  let lp = mmr % perTierLp
-  let grade: number | string = 4 - (a % 4)
+  let grade: number | string
   let tier
-  if (a === 0) tier = 'Unrank'
-  else if (a < 4) tier = 'Iron'
-  else if (a < 8) tier = 'Bronze'
-  else if (a < 12) tier = 'Silver'
-  else if (a < 16) tier = 'Gold'
-  else if (a < 20) tier = 'Platinum'
-  else if (a < 24) tier = 'Diamond'
-  else {
-    lp = mmr - 24 * perTierLp
-    grade = '' // 미스릴 이상 티어에서는 grade가 없음
-    if (lp >= 200 && rank <= 200) {
-      tier = 'Eternity'
-      if (seasonId < 19) lp -= 200 // 정식 시즌 이전에는 이터니티 달성시 lp 차감
-    } else if (rank > 700 && (seasonId ?? 15) >= 15) {
-      tier = 'Mithril' // 시즌8부터 미스릴 티어 추가
+  let lp
+  // 시즌 3 이후 점수 계산
+  if (seasonId >= 23) {
+    if (mmr < 1600) {
+      // 아이언, 브론즈의 디비전 구간 200점
+      perTierLp = 200
+      const a = Math.trunc(mmr / perTierLp)
+      grade = 4 - (a % 4)
+      lp = mmr % perTierLp
+      if (a < 4) {
+        tier = 'Iron'
+      } else {
+        tier = 'Bronze'
+      }
+    } else if (mmr < 3600) {
+      // 실버, 골드의 디비전 구간 250점
+      perTierLp = 250
+      const a = Math.trunc((mmr - 1600) / perTierLp)
+      grade = 4 - (a % 4)
+      lp = (mmr - 1600) % perTierLp
+      if (a < 4) {
+        tier = 'Silver'
+      } else {
+        tier = 'Gold'
+      }
+    } else if (mmr < 4800) {
+      // 플래티넘의 디비전 구간 300점
+      perTierLp = 300
+      const a = Math.trunc((mmr - 3600) / perTierLp)
+      grade = 4 - (a % 4)
+      lp = (mmr - 3600) % perTierLp
+      tier = 'Platinum'
+    } else if (mmr < 6200) {
+      // 다이아몬드의 디비전 구간 350점
+      perTierLp = 350
+      const a = Math.trunc((mmr - 4800) / perTierLp)
+      grade = 4 - (a % 4)
+      lp = (mmr - 4800) % perTierLp
+      tier = 'Diamond'
     } else {
-      tier = 'Demigod'
+      grade = '' // 미스릴 이상은 grade가 없음
+      lp = mmr - 6200
+      if (mmr >= 6400 && rank <= 200) {
+        //  6400점 이상, 랭킹 200위 이내 이터니티
+        tier = 'Eternity'
+      } else if (mmr >= 6400 && rank <= 700) {
+        // 6400점 이상, 랭킹 700위 이내 데미갓
+        tier = 'Demigod'
+      } else {
+        tier = 'Mithril'
+      }
+    }
+  } else {
+    // 시즌 2 이전 점수 계산
+    // 10 시즌(공식 1.0)부터 1티어당 250lp로 변경
+    if (seasonId >= 19) {
+      perTierLp = 250
+    } else {
+      perTierLp = 100
+    }
+    const a = Math.trunc(mmr / perTierLp)
+    lp = mmr % perTierLp
+    grade = 4 - (a % 4)
+    if (a === 0) tier = 'Unrank'
+    else if (a < 4) tier = 'Iron'
+    else if (a < 8) tier = 'Bronze'
+    else if (a < 12) tier = 'Silver'
+    else if (a < 16) tier = 'Gold'
+    else if (a < 20) tier = 'Platinum'
+    else if (a < 24) tier = 'Diamond'
+    else {
+      lp = mmr - 24 * perTierLp
+      grade = '' // 미스릴 이상 티어에서는 grade가 없음
+      if (lp >= 200 && rank <= 200) {
+        tier = 'Eternity'
+        if (seasonId < 19) lp -= 200 // 정식 시즌 이전에는 이터니티 달성시 lp 차감
+      } else if (rank > 700 && (seasonId ?? 15) >= 15) {
+        tier = 'Mithril' // 시즌8부터 미스릴 티어 추가
+      } else {
+        tier = 'Demigod'
+      }
     }
   }
 


### PR DESCRIPTION
- Tooltip이 화면 상하좌우 기준으로 적절한 방향으로 나타나게 수정하였습니다.
- 시즌3 변경된 티어 점수 계산식을 반영하였습니다.
- 프로필 화면에서 부동소수점 오류를 수정하였습니다.